### PR TITLE
Make windows binaries streamlined & update gitian-descriptors

### DIFF
--- a/divi/Dockerfile-for-windows
+++ b/divi/Dockerfile-for-windows
@@ -1,0 +1,41 @@
+FROM ubuntu:bionic
+
+RUN apt-get update
+RUN apt-get upgrade -y
+
+RUN apt-get install apt-utils -y
+RUN apt-get install bsdmainutils -y
+RUN apt-get install software-properties-common -y
+RUN add-apt-repository ppa:bitcoin/bitcoin -y
+
+RUN apt-get install make -y
+RUN apt-get install gcc -y
+RUN apt-get install g++ -y
+RUN apt-get install pkg-config -y
+RUN apt-get install autoconf -y
+RUN apt-get install libtool -y
+RUN apt-get install libboost-all-dev -y
+RUN apt-get install libssl1.0-dev -y
+RUN apt-get install libevent-dev -y
+RUN apt-get install libdb4.8-dev libdb4.8++-dev -y
+
+RUN apt-get install -y build-essential autotools-dev automake bsdmainutils curl
+RUN apt-get install -y libc6 libc6-dev
+
+WORKDIR /app
+COPY . .
+
+RUN apt-get install -y g++-mingw-w64-x86-64
+RUN update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix
+
+# Comment out the next three lines if you're not interested in building the dependencies
+WORKDIR /app/depends
+RUN make HOST=x86_64-w64-mingw32
+WORKDIR /app
+
+RUN PATH=$(echo "$PATH" | sed -e 's/:\/mnt.*//g')
+RUN ./autogen.sh
+RUN CONFIG_SITE=$PWD/depends/x86_64-w64-mingw32/share/config.site ./configure --disable-tests --without-gui --prefix=/ 
+RUN make
+
+CMD ["bash"]

--- a/divi/contrib/gitian-descriptors/gitian-win.yml
+++ b/divi/contrib/gitian-descriptors/gitian-win.yml
@@ -144,8 +144,9 @@ script: |
     CONFIG_SITE=${BASEPREFIX}/${i}/share/config.site ./configure --prefix=/ --disable-ccache --disable-maintainer-mode --disable-dependency-tracking ${CONFIGFLAGS} CFLAGS="${HOST_CFLAGS}" CXXFLAGS="${HOST_CXXFLAGS}"
     make ${MAKEOPTS}
 
-    mkdir -p $OUTDIR/bin
-    cp `pwd`/src/divi*.exe  $OUTDIR/bin
+    mkdir -p $OUTDIR/bin/${DISTNAME}-${i}
+    cp `pwd`/src/divi*.exe  $OUTDIR/bin/${DISTNAME}-${i}
+    zip -r $OUTDIR/${DISTNAME}-${i}.zip $OUTDIR/bin/${DISTNAME}-${i}
     #make deploy
     #make install DESTDIR=${INSTALLPATH}
     #cp -f divi-*setup*.exe $OUTDIR/
@@ -161,6 +162,7 @@ script: |
     cd ../../
     rm -rf distsrc-${i}
   done
+  rm -rf $OUTDIR/bin
   #cd $OUTDIR
   #rename 's/-setup\.exe$/-setup-unsigned.exe/' *-setup.exe
   #find . -name "*-setup-unsigned.exe" | sort | tar --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | gzip -9n > ${OUTDIR}/${DISTNAME}-win-unsigned.tar.gz

--- a/divi/contrib/gitian-descriptors/gitian-win.yml
+++ b/divi/contrib/gitian-descriptors/gitian-win.yml
@@ -101,7 +101,7 @@ script: |
   create_per-host_linker_wrapper "2000-01-01 12:00:00"
   export PATH=${WRAP_DIR}:${PATH}
 
-  cd divi
+  cd divi/divi
   BASEPREFIX=`pwd`/depends
   # Build dependencies for each host
   for i in $HOSTS; do
@@ -143,25 +143,28 @@ script: |
 
     CONFIG_SITE=${BASEPREFIX}/${i}/share/config.site ./configure --prefix=/ --disable-ccache --disable-maintainer-mode --disable-dependency-tracking ${CONFIGFLAGS} CFLAGS="${HOST_CFLAGS}" CXXFLAGS="${HOST_CXXFLAGS}"
     make ${MAKEOPTS}
-    make deploy
-    make install DESTDIR=${INSTALLPATH}
-    cp -f divi-*setup*.exe $OUTDIR/
+
+    mkdir -p $OUTDIR/bin
+    cp `pwd`/src/divi*.exe  $OUTDIR/bin
+    #make deploy
+    #make install DESTDIR=${INSTALLPATH}
+    #cp -f divi-*setup*.exe $OUTDIR/
     cd installed
     # mv ${DISTNAME}/bin/*.dll ${DISTNAME}/lib/ # temporarily disabled for Zerocoin
     # find . -name "lib*.la" -delete            # temporarily disabled for Zerocoin
     # find . -name "lib*.a" -delete             # temporarily disabled for Zerocoin
     rm -rf ${DISTNAME}/lib/pkgconfig
-    find ${DISTNAME}/bin -type f -executable -exec ${i}-objcopy --only-keep-debug {} {}.dbg \; -exec ${i}-strip -s {} \; -exec ${i}-objcopy --add-gnu-debuglink={}.dbg {} \;
+    #find ${DISTNAME}/bin -type f -executable -exec ${i}-objcopy --only-keep-debug {} {}.dbg \; -exec ${i}-strip -s {} \; -exec ${i}-objcopy --add-gnu-debuglink={}.dbg {} \;
     # find ${DISTNAME}/lib -type f -exec ${i}-objcopy --only-keep-debug {} {}.dbg \; -exec ${i}-strip -s {} \; -exec ${i}-objcopy --add-gnu-debuglink={}.dbg {} \;
-    find ${DISTNAME} -not -name "*.dbg"  -type f | sort | zip -X@ ${OUTDIR}/${DISTNAME}-${i}.zip
-    find ${DISTNAME} -name "*.dbg"  -type f | sort | zip -X@ ${OUTDIR}/${DISTNAME}-${i}-debug.zip
+    # find ${DISTNAME} -not -name "*.dbg"  -type f | sort | zip -X@ ${OUTDIR}/${DISTNAME}-${i}.zip
+    # find ${DISTNAME} -name "*.dbg"  -type f | sort | zip -X@ ${OUTDIR}/${DISTNAME}-${i}-debug.zip
     cd ../../
     rm -rf distsrc-${i}
   done
-  cd $OUTDIR
-  rename 's/-setup\.exe$/-setup-unsigned.exe/' *-setup.exe
-  find . -name "*-setup-unsigned.exe" | sort | tar --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | gzip -9n > ${OUTDIR}/${DISTNAME}-win-unsigned.tar.gz
-  mv ${OUTDIR}/${DISTNAME}-x86_64-*-debug.zip ${OUTDIR}/${DISTNAME}-win64-debug.zip
-  mv ${OUTDIR}/${DISTNAME}-i686-*-debug.zip ${OUTDIR}/${DISTNAME}-win32-debug.zip
-  mv ${OUTDIR}/${DISTNAME}-x86_64-*.zip ${OUTDIR}/${DISTNAME}-win64.zip
-  mv ${OUTDIR}/${DISTNAME}-i686-*.zip ${OUTDIR}/${DISTNAME}-win32.zip
+  #cd $OUTDIR
+  #rename 's/-setup\.exe$/-setup-unsigned.exe/' *-setup.exe
+  #find . -name "*-setup-unsigned.exe" | sort | tar --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | gzip -9n > ${OUTDIR}/${DISTNAME}-win-unsigned.tar.gz
+  #mv ${OUTDIR}/${DISTNAME}-x86_64-*-debug.zip ${OUTDIR}/${DISTNAME}-win64-debug.zip
+  #mv ${OUTDIR}/${DISTNAME}-i686-*-debug.zip ${OUTDIR}/${DISTNAME}-win32-debug.zip
+  #mv ${OUTDIR}/${DISTNAME}-x86_64-*.zip ${OUTDIR}/${DISTNAME}-win64.zip
+  #mv ${OUTDIR}/${DISTNAME}-i686-*.zip ${OUTDIR}/${DISTNAME}-win32.zip


### PR DESCRIPTION
Usage for the Dockerfile-for-windows: 
docker build -f Dockerfile-for-windows -t my_tag .

This docker file builds the dependencies by default and is slow.
May take about 1-2h depending on harware but need only be done
once.