### PR TITLE
Expand remote MN deployment functionality

### DIFF
--- a/divi/src/activemasternode.cpp
+++ b/divi/src/activemasternode.cpp
@@ -205,16 +205,20 @@ bool CActiveMasternode::SendMasternodePing(std::string& errorMessage)
 }
 
 bool CActiveMasternode::Register(
-    std::string strService, 
-    std::string strKeyMasternode,
-    std::string strTxHash, 
-    std::string strOutputIndex, 
+    const CMasternodeConfig::CMasternodeEntry& configEntry, 
     std::string& errorMessage,
     CMasternodeBroadcast& mnb,
     bool deferRelay)
 {
-    if(!CMasternodeBroadcastFactory::Create(strService, strKeyMasternode, strTxHash, strOutputIndex, errorMessage, mnb, false,deferRelay))
+    if(!CMasternodeBroadcastFactory::Create(
+            configEntry,
+            errorMessage,
+            mnb,
+            false,
+            deferRelay))
+    {
         return false;
+    }
 
     addrman.Add(CAddress(mnb.addr), CNetAddr("127.0.0.1"), 2 * 60 * 60);
     return Register(mnb,deferRelay);

--- a/divi/src/activemasternode.h
+++ b/divi/src/activemasternode.h
@@ -9,10 +9,12 @@
 #include "init.h"
 #include "key.h"
 #include "masternode.h"
+#include "masternodeconfig.h"
 #include "net.h"
 #include "obfuscation.h"
 #include "sync.h"
 #include "wallet.h"
+
 
 #define ACTIVE_MASTERNODE_INITIAL 0 // initial state
 #define ACTIVE_MASTERNODE_SYNC_IN_PROCESS 1
@@ -60,10 +62,7 @@ public:
 
     /// Register remote Masternode
     static bool Register(
-        std::string strService, 
-        std::string strKey, 
-        std::string strTxHash, 
-        std::string strOutputIndex, 
+        const CMasternodeConfig::CMasternodeEntry& configEntry, 
         std::string& errorMessage,
         CMasternodeBroadcast& mnb,
         bool deferRelay = false);

--- a/divi/src/masternode.cpp
+++ b/divi/src/masternode.cpp
@@ -637,7 +637,7 @@ bool CMasternodeBroadcastFactory::Create(const CMasternodeConfig::CMasternodeEnt
                     bool fOffline)
 {
     const bool collateralPrivateKeyIsRemote = true;
-    const bool deferRelay = false;
+    const bool deferRelay = true;
     CTxIn txin;
     std::pair<CKey,CPubKey> masternodeCollateralKeyPair;
     std::pair<CKey,CPubKey> masternodeKeyPair;

--- a/divi/src/masternode.h
+++ b/divi/src/masternode.h
@@ -356,7 +356,13 @@ public:
                        CMasternodeBroadcast& mnbRet, 
                        bool fOffline = false,
                        bool deferRelay = false);
-    
+
+    static bool Create(const CMasternodeConfig::CMasternodeEntry configEntry,
+                       CPubKey pubkeyCollateralAddress,
+                       std::string& strErrorRet, 
+                       CMasternodeBroadcast& mnbRet, 
+                       bool fOffline = false); 
+private:    
     static void createWithoutSignatures(
         CTxIn txin, 
         CService service,
@@ -366,7 +372,6 @@ public:
         bool deferRelay,
         CMasternodeBroadcast& mnbRet);
 
-private:
     static bool signPing(
         CKey keyMasternodeNew, 
         CPubKey pubKeyMasternodeNew,
@@ -404,6 +409,7 @@ private:
         const std::string& txHash, 
         const std::string& outputIndex,
         const std::string& service,
+        bool collateralPrivKeyIsRemote,
         CTxIn& txin,
         std::pair<CKey,CPubKey>& masternodeCollateralKeyPair,
         std::string& error);
@@ -417,6 +423,15 @@ private:
     static bool checkNetworkPort(
         const std::string& strService,
         std::string& strErrorRet);
+    static bool createArgumentsFromConfig(
+        const CMasternodeConfig::CMasternodeEntry configEntry, 
+        std::string& strErrorRet,
+        bool fOffline,
+        bool collateralPrivKeyIsRemote,
+        CTxIn& txin,
+        std::pair<CKey,CPubKey>& masternodeKeyPair,
+        std::pair<CKey,CPubKey>& masternodeCollateralKeyPair,
+        CMasternode::Tier& nMasternodeTier);
 };
 
 #endif

--- a/divi/src/rpcmasternode.cpp
+++ b/divi/src/rpcmasternode.cpp
@@ -277,9 +277,10 @@ Value setupmasternode(const Array& params, bool fHelp)
     CMasternodeBroadcastFactory::createWithoutSignatures(vin,service,pubkeyForCollateral,masternodePubKey, masternodeTier,false,mnb);
 
     CDataStream ss(SER_NETWORK,PROTOCOL_VERSION);
-    ss << mnb;
     result.push_back(Pair("protocol_version", PROTOCOL_VERSION ));
-    result.push_back(Pair("broadcastData", charStringToHexString(ss.str()) ));
+    result.push_back(Pair("message_to_sign", mnb.getMessageToSign()));
+    ss << mnb;
+    result.push_back(Pair("broadcast_data", charStringToHexString(ss.str()) ));
     return result;    
 }
 

--- a/divi/src/rpcmasternode.cpp
+++ b/divi/src/rpcmasternode.cpp
@@ -55,17 +55,23 @@ static std::vector<unsigned char> hexToUCharVector(const std::string& hexString)
         };
 
     std::vector<unsigned char> result;
+    if(hexString.size() % 2 != 0)
+    {
+        return result;
+    }
+    result.reserve(hexString.size()/2);
+
     uint8_t leadingHexAsUint;
     uint8_t trailingHexAsUint;
     for(auto it = hexString.begin(); it != hexString.end(); ++it)
     {
         if(!toNumeric(*it++,leadingHexAsUint) ||
-           !toNumeric(*it++,trailingHexAsUint))
+           !toNumeric(*it,trailingHexAsUint))
         {
             result.clear();
             return result;
         }
-        leadingHexAsUint << 4;
+        leadingHexAsUint = leadingHexAsUint << 4;
         result.push_back( static_cast<unsigned char>( (leadingHexAsUint + trailingHexAsUint) ) );
     }
     return result;

--- a/divi/src/rpcmasternode.cpp
+++ b/divi/src/rpcmasternode.cpp
@@ -475,8 +475,9 @@ Value broadcaststartmasternode(const Array& params, bool fHelp)
         mnb.sig = std::vector<unsigned char>(decodedSignature.begin(),decodedSignature.end());
     }
 
-    int DoS = 0;
-    if(mnb.CheckInputsAndAdd(DoS))
+    int nDoS = 0;
+    if(mnb.CheckAndUpdate(nDoS) && 
+        mnb.CheckInputsAndAdd(nDoS))
     {
         mnb.Relay();
         result.push_back(Pair("status", "success"));

--- a/divi/src/rpcserver.cpp
+++ b/divi/src/rpcserver.cpp
@@ -328,6 +328,7 @@ static const CRPCCommand vRPCCommands[] =
         {"divi", "masternodeconnect", &masternodeconnect, true, true, false},
         {"divi", "masternodecurrent", &masternodecurrent, true, true, false},
         // {"divi", "masternodedebug", &masternodedebug, true, true, false},
+        {"divi","setupmasternode",&setupmasternode,true,false,true},
         {"divi", "broadcaststartmasternode", &broadcaststartmasternode, true, true, false},
         {"divi", "startmasternode", &startmasternode, true, true, false},
         {"divi", "createmasternodekey", &createmasternodekey, true, true, false},

--- a/divi/src/rpcserver.h
+++ b/divi/src/rpcserver.h
@@ -272,6 +272,7 @@ extern json_spirit::Value getmasternodecount(const json_spirit::Array& params, b
 extern json_spirit::Value masternodeconnect(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value masternodecurrent(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value masternodedebug(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value setupmasternode(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value broadcaststartmasternode(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value startmasternode(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value createmasternodekey(const json_spirit::Array& params, bool fHelp);

--- a/divi/src/rpcwallet.cpp
+++ b/divi/src/rpcwallet.cpp
@@ -449,14 +449,15 @@ Value listaddressgroupings(const Array& params, bool fHelp)
 
 Value signmessage(const Array& params, bool fHelp)
 {
-    if (fHelp || params.size() != 2)
+    if (fHelp || params.size() < 2 || params.size() > 3)
         throw runtime_error(
                 "signmessage \"diviaddress\" \"message\"\n"
                 "\nSign a message with the private key of an address" +
                 HelpRequiringPassphrase() + "\n"
                                             "\nArguments:\n"
-                                            "1. \"diviaddress\"  (string, required) The divi address to use for the private key.\n"
-                                            "2. \"message\"         (string, required) The message to create a signature of.\n"
+                                            "1. \"diviaddress\"    (string, required) The divi address to use for the private key.\n"
+                                            "2. \"message\"        (string, required) The message to create a signature of.\n"
+                                            "2. \"format\"         (string, optional) Message encoding format. Default plaintext\n"
                                             "\nResult:\n"
                                             "\"signature\"          (string) The signature of the message encoded in base 64\n"
                                             "\nExamples:\n"
@@ -470,7 +471,19 @@ Value signmessage(const Array& params, bool fHelp)
 
     string strAddress = params[0].get_str();
     string strMessage = params[1].get_str();
-
+    if(params.size()==3)
+    {
+        string format = static_cast<string>(params[2].get_str());
+        if(std::strcmp(format.c_str(),"hex")==0)
+        {
+            valtype decodedHex = ParseHex(strMessage);
+            strMessage = string(decodedHex.begin(),decodedHex.end());
+        }
+        else if(std::strcmp(format.c_str(),"b64")==0)
+        {
+            strMessage = DecodeBase64(strMessage);
+        }
+    }
     CBitcoinAddress addr(strAddress);
     if (!addr.IsValid())
         throw JSONRPCError(RPC_TYPE_ERROR, "Invalid address");


### PR DESCRIPTION
Additions:

1. Simplify method parameters
2. Refactoring signature steps to allow for deferred signing
3. Expand CLI signing functionality for hex encoded messages
4. 'broadcaststartmasternode' now allows appending of collateral signature.
5. 'setupmasternode' method allows generating a partial broadcast data hex & a hex message that needs a signature from the controlling wallet - for use with 'broadcaststartmasternode' by appending the signature to the partial broadcast data internally