### PR TITLE
Remote start usability improvements

### DIFF
--- a/divi/src/masternode.cpp
+++ b/divi/src/masternode.cpp
@@ -1027,7 +1027,7 @@ CMasternodePing CMasternodePing::createDelayedMasternodePing(CTxIn& newVin)
     ping.vin = newVin;
     auto block = chainActive[chainActive.Height() -12];
     ping.blockHash = block->GetBlockHash();
-    ping.sigTime = block->GetBlockTime() + offsetTimeBy45BlocksInSeconds;
+    ping.sigTime = std::max(block->GetBlockTime() + offsetTimeBy45BlocksInSeconds, GetAdjustedTime());
     ping.vchSig = std::vector<unsigned char>();
     LogPrint("masternode","mnp - relay block-time & sigtime: %d vs. %d\n", block->GetBlockTime(), ping.sigTime);
 

--- a/divi/src/masternode.cpp
+++ b/divi/src/masternode.cpp
@@ -563,9 +563,12 @@ bool CMasternodeBroadcastFactory::checkMasternodeCollateral(
     std::string& strErrorRet)
 {
     nMasternodeTier = CMasternode::Tier::MASTERNODE_TIER_INVALID;
-    if(auto walletTx = pwalletMain->GetWalletTx(txin.prevout.hash))
+    auto walletTx = pwalletMain->GetWalletTx(txin.prevout.hash);
+    uint256 blockHash;
+    CTransaction fundingTx;
+    if(walletTx || GetTransaction(txin.prevout.hash,fundingTx,blockHash,true))
     {
-        auto collateralAmount = walletTx->vout.at(txin.prevout.n).nValue;
+        auto collateralAmount = (walletTx)? walletTx->vout.at(txin.prevout.n).nValue: fundingTx.vout[txin.prevout.n].nValue;
         nMasternodeTier = CMasternode::GetTierByCollateralAmount(collateralAmount);
         if(!CMasternode::IsTierValid(nMasternodeTier))
         {

--- a/divi/src/rpcmasternode.cpp
+++ b/divi/src/rpcmasternode.cpp
@@ -403,7 +403,7 @@ Value broadcaststartmasternode(const Array& params, bool fHelp)
 {
     if (fHelp || params.size() > 2 || params.size() < 1)
         throw runtime_error(
-            "broadcaststartmasternode hex\n"
+            "broadcaststartmasternode hex sig\n"
             "\nVerifies the escrowed funds for the masternode and returns the necessary info for your and its configuration files.\n"
 
             "\nArguments:\n"
@@ -413,11 +413,10 @@ Value broadcaststartmasternode(const Array& params, bool fHelp)
             "\"status\"	(string) status of broadcast\n");
 
     Object result;
-    CMasternodeBroadcast mnb = readFromHex<CMasternodeBroadcast>(params.at(0).get_str());
+    CMasternodeBroadcast mnb = readFromHex<CMasternodeBroadcast>(params[0].get_str());
     if(params.size()==2) 
     {
-        std::string decodedSignature = DecodeBase64(params.at(1).get_str());
-        mnb.sig = std::vector<unsigned char>(decodedSignature.begin(),decodedSignature.end());
+        mnb.sig = ParseHex(params[1].get_str());
     }
 
     int nDoS = 0;

--- a/divi/src/rpcmasternode.cpp
+++ b/divi/src/rpcmasternode.cpp
@@ -81,13 +81,17 @@ Value allocatefunds(const Array& params, bool fHelp)
 			"\"vin\"			(string) funding transaction id necessary for next step.\n");
 
     if (params[0].get_str() != "masternode")
+    {
         throw runtime_error("Surely you meant the first argument to be ""masternode"" . . . . ");
+    }
 	CBitcoinAddress acctAddr = GetAccountAddress("alloc->" + params[1].get_str());
 	string strAmt = params[2].get_str();
 
     auto nMasternodeTier = GetMasternodeTierFromString(strAmt);
     if(!CMasternode::IsTierValid(nMasternodeTier))
+    {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid masternode tier");
+    }
 
 	CWalletTx wtx;
     SendMoney(acctAddr.Get(), CMasternode::GetTierCollateralAmount(nMasternodeTier), wtx);
@@ -119,7 +123,9 @@ Value fundmasternode(const Array& params, bool fHelp)
     auto nMasternodeTier = GetMasternodeTierFromString(params[1].get_str());
 
     if(!CMasternode::IsTierValid(nMasternodeTier))
+    {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid masternode tier");
+    }
 
 	uint256 txHash = uint256(params[2].get_str());
 	std::string mnAddress = params[3].get_str();
@@ -283,12 +289,10 @@ Value listmasternodes(const Array& params, bool fHelp)
             HelpExampleCli("masternodelist", "") + HelpExampleRpc("masternodelist", ""));
 
     Array ret;
-    int nHeight;
     {
         LOCK(cs_main);
         CBlockIndex* pindex = chainActive.Tip();
         if(!pindex) return 0;
-        nHeight = pindex->nHeight;
     }
     for(auto &&entry : mnodeman.GetFullMasternodeVector()) {
         Object obj;

--- a/divi/src/rpcmasternode.cpp
+++ b/divi/src/rpcmasternode.cpp
@@ -22,61 +22,6 @@
 #include <fstream>
 using namespace json_spirit;
 
-static std::string charStringToHexString(const std::string& charString)
-{
-    const char hexCharacters[] = {'0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f'};
-    std::stringstream ss;
-    for(auto it = charString.begin(); it != charString.end(); ++it)
-    {
-        uint8_t charAsUint = *it;
-        ss << hexCharacters[(charAsUint & 0xF0) >> 4];
-        ss << hexCharacters[(charAsUint & 0x0F)];
-    }
-    return ss.str();
-}
-
-static std::vector<unsigned char> hexToUCharVector(const std::string& hexString)
-{
-    const char hexCharacters[] = {'0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f'};
-    auto toNumeric = [hexCharacters](const char value,uint8_t& out) -> bool {
-        const char* start = &hexCharacters[0];
-        const char* end = start +16;
-        auto it = std::find(start,end,value);
-        if(it == end)
-        {
-            out = uint8_t(0);
-            return false;
-        }
-        else
-        {
-            out = static_cast<uint8_t>(it - &hexCharacters[0]);
-            return true;
-        }
-        };
-
-    std::vector<unsigned char> result;
-    if(hexString.size() % 2 != 0)
-    {
-        return result;
-    }
-    result.reserve(hexString.size()/2);
-
-    uint8_t leadingHexAsUint;
-    uint8_t trailingHexAsUint;
-    for(auto it = hexString.begin(); it != hexString.end(); ++it)
-    {
-        if(!toNumeric(*it++,leadingHexAsUint) ||
-           !toNumeric(*it,trailingHexAsUint))
-        {
-            result.clear();
-            return result;
-        }
-        leadingHexAsUint = leadingHexAsUint << 4;
-        result.push_back( static_cast<unsigned char>( (leadingHexAsUint + trailingHexAsUint) ) );
-    }
-    return result;
-}
-
 template <typename T>
 static T readFromHex(std::string hexString)
 {
@@ -278,9 +223,9 @@ Value setupmasternode(const Array& params, bool fHelp)
 
     CDataStream ss(SER_NETWORK,PROTOCOL_VERSION);
     result.push_back(Pair("protocol_version", PROTOCOL_VERSION ));
-    result.push_back(Pair("message_to_sign", charStringToHexString(mnb.getMessageToSign()) ));
+    result.push_back(Pair("message_to_sign", HexStr(mnb.getMessageToSign()) ));
     ss << mnb;
-    result.push_back(Pair("broadcast_data", charStringToHexString(ss.str()) ));
+    result.push_back(Pair("broadcast_data", HexStr(ss.str()) ));
     return result;    
 }
 
@@ -525,7 +470,7 @@ Value startmasternode(const Array& params, bool fHelp)
                 {
                     CDataStream ss(SER_NETWORK,PROTOCOL_VERSION);
                     ss << mnb;
-                    result.push_back(Pair("broadcastData", charStringToHexString(ss.str()) ));
+                    result.push_back(Pair("broadcastData", HexStr(ss.str()) ));
                 }
                 fFound = true;
             }

--- a/divi/src/rpcwallet.cpp
+++ b/divi/src/rpcwallet.cpp
@@ -449,15 +449,16 @@ Value listaddressgroupings(const Array& params, bool fHelp)
 
 Value signmessage(const Array& params, bool fHelp)
 {
-    if (fHelp || params.size() < 2 || params.size() > 3)
+    if (fHelp || params.size() < 2 || params.size() > 4)
         throw runtime_error(
-                "signmessage \"diviaddress\" \"message\"\n"
+                "signmessage \"diviaddress\" \"message\" \"input_format\" \"output_format\"\n"
                 "\nSign a message with the private key of an address" +
                 HelpRequiringPassphrase() + "\n"
                                             "\nArguments:\n"
                                             "1. \"diviaddress\"    (string, required) The divi address to use for the private key.\n"
                                             "2. \"message\"        (string, required) The message to create a signature of.\n"
-                                            "2. \"format\"         (string, optional) Message encoding format. Default plaintext\n"
+                                            "3. \"input_format\"   (string, optional) ['hex'] Message encoding format. Default plaintext\n"
+                                            "4. \"output_format\"  (string, optional) ['hex'] Message encoding format. Default base64\n"
                                             "\nResult:\n"
                                             "\"signature\"          (string) The signature of the message encoded in base 64\n"
                                             "\nExamples:\n"
@@ -504,6 +505,14 @@ Value signmessage(const Array& params, bool fHelp)
     if (!key.SignCompact(ss.GetHash(), vchSig))
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Sign failed");
 
+    if(params.size()==4)
+    {
+        string outputFormat = static_cast<string>(params[3].get_str());
+        if(std::strcmp(outputFormat.c_str(),"hex")==0)
+        {
+            return HexStr(vchSig);
+        }
+    }
     return EncodeBase64(&vchSig[0], vchSig.size());
 }
 

--- a/divi/src/rpcwallet.cpp
+++ b/divi/src/rpcwallet.cpp
@@ -1171,7 +1171,7 @@ void ListTransactions(const CWalletTx& wtx, const string& strAccount, int nMinDe
     bool fAllAccounts = (strAccount == string("*"));
 
     if (wtx.IsCoinStake()) {
-        int64_t nTime = wtx.GetComputedTxTime();
+        wtx.GetComputedTxTime();
         CAmount nCredit = wtx.GetCredit(ISMINE_ALL);
         CAmount nDebit = wtx.GetDebit(ISMINE_ALL);
         CAmount nNet = nCredit - nDebit;


### PR DESCRIPTION
- Added rpc signature extensions for signing hex messages
- Use hex encoding to provide signatures to broadcast
- Check for transactions external to the wallet when checking collateral
- Provide rpc config_line on the remote node when setting up a Masternode
- Fixed timestamp bug that made invoking setupmasternode expired for older transactions