### PR TITLE
Added .github issue and pr templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.MD
+++ b/.github/ISSUE_TEMPLATE.MD
@@ -1,0 +1,11 @@
+### Description
+
+[//]: # (Describe the issue you are experiencing. Can be a brief description of what went wrong.)
+
+### Environment
+
+[//]: # (The environment you experienced the issue. ie: Ubuntu 18.04. If possible, provide versions of the packages you used if they are different to a standard build.)
+
+### Notes
+
+[//]: # (Any other notes in regards to the issue.)

--- a/.github/PULL_REQUEST_TEMPLATE.MD
+++ b/.github/PULL_REQUEST_TEMPLATE.MD
@@ -1,0 +1,11 @@
+### Feature
+
+[//]: # (A brief outline of the feature implemented.)
+
+### Description
+
+[//]: # (A brief description of the changes that were implemented.)
+
+### Notes
+
+[//]: # (Any other notes in regards to the pull request.)


### PR DESCRIPTION
### Feature

This provides markdown to use as a reference when creating issues and PRs. Does not have to be strictly followed, but is just general-purpose guidance for formatting and documentation.

### Description

Added the following files in `.github`

- `.github/ISSUE_TEMPLATE.MD`

- `.github/PULL_REQUEST_TEMPLATE.MD`
