### PR TITLE
Provide clear/list-ing of banned nodes

### DIFF
--- a/divi/src/net.cpp
+++ b/divi/src/net.cpp
@@ -507,7 +507,21 @@ CCriticalSection CNode::cs_setBanned;
 
 void CNode::ClearBanned()
 {
+    LOCK(cs_setBanned);
     setBanned.clear();
+}
+
+std::string CNode::ListBanned()
+{
+    std::string bannedIps = "[\n";
+    LOCK(cs_setBanned);
+    for(auto banned: setBanned)
+    {
+        bannedIps += banned.first.ToString();
+        bannedIps += ",\n";
+    }
+    bannedIps += "]";
+    return bannedIps;
 }
 
 bool CNode::IsBanned(CNetAddr ip)

--- a/divi/src/net.h
+++ b/divi/src/net.h
@@ -610,6 +610,7 @@ public:
     // between nodes running old code and nodes running
     // new code.
     static void ClearBanned(); // needed for unit testing
+    static std::string ListBanned();
     static bool IsBanned(CNetAddr ip);
     static bool Ban(const CNetAddr& ip);
     void copyStats(CNodeStats& stats);

--- a/divi/src/rpcmisc.cpp
+++ b/divi/src/rpcmisc.cpp
@@ -1041,6 +1041,30 @@ Value getaddressutxos(const Array& params, bool fHelp)
     }
 }
 
+Value clearbanned(const Array& params, bool fHelp)
+{
+    if (fHelp || params.size() > 1)
+        throw runtime_error(
+            "clearbanned\n"
+            "\nUnbans all nodes.\n"
+            );
+    CNode::ClearBanned();
+    return Value();    
+
+}
+Value listbanned(const Array& params, bool fHelp)
+{
+    if (fHelp || params.size() > 1)
+        throw runtime_error(
+            "clearbanned\n"
+            "\nUnbans all nodes.\n"
+            );
+    Object result;
+    result.push_back(Pair("banned:",CNode::ListBanned()));
+    return result;    
+
+}
+
 #ifdef ENABLE_WALLET
 Value getstakingstatus(const Array& params, bool fHelp)
 {

--- a/divi/src/rpcserver.cpp
+++ b/divi/src/rpcserver.cpp
@@ -349,6 +349,8 @@ static const CRPCCommand vRPCCommands[] =
         {"divi", "mnsync", &mnsync, true, true, false},
         {"divi", "spork", &spork, true, true, false},
         {"divi", "getpoolinfo", &getpoolinfo, true, true, false},
+        {"divi","clearbanned",&clearbanned,false,false,false},
+        {"divi","listbanned",&listbanned,false,false,false},
 
         /* address index */
         { "addressindex", "getaddresstxids", &getaddresstxids, false, false, false },

--- a/divi/src/rpcserver.h
+++ b/divi/src/rpcserver.h
@@ -307,6 +307,8 @@ extern json_spirit::Value getaddressbalance(const json_spirit::Array& params, bo
 extern json_spirit::Value getaddressutxos(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getaddressmempool(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getspentinfo(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value clearbanned(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value listbanned(const json_spirit::Array& params, bool fHelp);
 
 // in rest.cpp
 extern bool HTTPReq_REST(AcceptedConnection* conn,


### PR DESCRIPTION
### Feature

[//]: # At times there may be a moment where due to failures in networking may cause a node to ban an excessive number of peers, as a result the network becomes fragmented. For that reason it is desirable to have a 'reset' option for un-banning peers. This PR contains that by providing listing and clearing functionality for banned peers.

### Description

[//]: # Added two rpc endpoints. One for each method. Additionally expanded the CNode class to enable listing peers and ensuring that clearing peers is done in a thread safe way.

### Notes

[//]: # This PR repurposes ClearBanned for a usage other than just unit testing.
